### PR TITLE
Fix define-values typo

### DIFF
--- a/irc-client/scribblings/irc-client.scrbl
+++ b/irc-client/scribblings/irc-client.scrbl
@@ -24,7 +24,7 @@ This library provides a set of constructs for interacting with IRC servers in Ra
 a server, use @racket[irc-connect].
 
 @(racketblock
-  (define (conn ready-evt) (irc-connect "irc.example.com" 6667
+  (define-values (conn ready-evt) (irc-connect "irc.example.com" 6667
                                         "nickname" "username" "Real Name"))
   (sync ready-evt))
 


### PR DESCRIPTION
I'm pretty sure that this is just a simple typo. The define command as written creates a function called "conn", when I'm pretty sure that what you actually want to do is return two values called "conn" and "ready-evt".
