### PR TITLE
Created function irc-recv-evt

### DIFF
--- a/irc-client/main.rkt
+++ b/irc-client/main.rkt
@@ -97,10 +97,10 @@
 
 (: irc-recv-evt (IrcConnection -> (Evtof IrcMessage)))
 (define (irc-recv-evt connection)
-  (define (handle message)
+  (define (handle [message : (U irc:irc-message EOF)])
     (if (eof-object? message)
         (error "irc connection closed")
-        (parse-irc-message (cast message irc:irc-message))))
+        (parse-irc-message message)))
   (handle-evt (irc:irc-connection-incoming (IrcConnection-internal-connection connection))
               handle))
 

--- a/irc-client/scribblings/irc-client.scrbl
+++ b/irc-client/scribblings/irc-client.scrbl
@@ -109,6 +109,12 @@ block until a message arrives.
 
 If the connection is closed, an @racket[exn:fail] will be raised.}
 
+@defproc[(irc-recv-evt [connection IrcConnection]) (Evtof IrcMessage)]{
+Returns a synchronizable event that waits for an incoming message from the connection. The synchronization
+result is the @racket[IrcMessage] recieved.
+
+If the connection is closed, an @racket[exn:fail] will be raised.}
+
 @section{Structure Types}
 
 @defstruct*[IrcConnection ([internal-connection irc:irc-connection?]) #:transparent]{


### PR DESCRIPTION
Created `irc-recv-evt` function that exposes the racket event API (`sync` and friends). This allows you to make more idiomatic event-based code, as opposed to only having the option to block.

Currently using it in my client like so:
```racket
  (define evt
    (apply choice-evt
           (for/list ([con (in-list connections)])
             (handle-evt (irc-recv-evt con)
                         (λ (msg) (cons con msg))))))
```