### PR TITLE
Expose SSL connection feature from underlying irc library.

### DIFF
--- a/irc-client/main.rkt
+++ b/irc-client/main.rkt
@@ -52,10 +52,12 @@
 (struct IrcMessage-Kill IrcMessage ([user : IrcUser] [killed-user : String] [reason : String]) #:transparent)
 (struct IrcMessage-Nick IrcMessage ([user : IrcUser] [new-nick : String]) #:transparent)
 
-(: irc-connect (String Nonnegative-Integer String String String
-                       -> (values IrcConnection (Evtof Semaphore))))
-(define (irc-connect server port nick username real-name)
-  (let-values ([(connection event) (irc:irc-connect server port nick username real-name)])
+(: irc-connect (->* (String Nonnegative-Integer String String String)
+                    (#:ssl (U Boolean 'auto 'sslv2-or-v3 'sslv2 'sslv3 'tls 'tls11 'tls12)
+                     #:return-eof Boolean)
+                    (values IrcConnection (Evtof Semaphore))))
+(define (irc-connect server port nick username real-name #:ssl [ssl #f] #:return-eof [eof #f])
+  (let-values ([(connection event) (irc:irc-connect server port nick username real-name #:ssl ssl #:return-eof eof)])
     (values (IrcConnection connection) event)))
 
 (: irc-join-channel! (IrcConnection String -> Void))

--- a/irc-client/private/typed/irc.rkt
+++ b/irc-client/private/typed/irc.rkt
@@ -8,7 +8,8 @@
                         [content : String])]
  [#:opaque irc-connection irc-connection?]
  [irc-connect (String Nonnegative-Integer String String String
-                      [#:return-eof Any]
+                      [#:ssl (U Boolean 'auto 'sslv2-or-v3 'sslv2 'sslv3 'tls 'tls11 'tls12)]
+                      [#:return-eof Boolean]
                       -> (values irc-connection (Evtof Semaphore)))]
  [irc-connection-incoming (irc-connection -> (Async-Channelof (U irc-message EOF)))]
  [irc-join-channel (irc-connection String -> Void)]

--- a/irc-client/scribblings/irc-client.scrbl
+++ b/irc-client/scribblings/irc-client.scrbl
@@ -24,8 +24,9 @@ This library provides a set of constructs for interacting with IRC servers in Ra
 a server, use @racket[irc-connect].
 
 @(racketblock
-  (define-values (conn ready-evt) (irc-connect "irc.example.com" 6667
-                                               "nickname" "username" "Real Name"))
+  (define-values (conn ready-evt) (irc-connect "irc.example.com" 6697
+                                               "nickname" "username" "Real Name"
+                                               #:ssl 'auto))
   (sync ready-evt))
 
 The second value returned from @racket[irc-connect] is a


### PR DESCRIPTION
- Makes it possible to access optional keyword arguments for irc-connect.
- Document optional #:ssl keyword.